### PR TITLE
Create Upgrading-Cacti-Under-Windows.md

### DIFF
--- a/Upgrading-Cacti-Under-Windows.md
+++ b/Upgrading-Cacti-Under-Windows.md
@@ -1,0 +1,53 @@
+# Upgrading Cacti under Windows
+> Download latest cacti-xxx.zip
+
+1. Stop poller.  Cacti > Configuration > Settings > Poller > uncheck Data Collection Enabled and Save.
+
+2. Run Command Prompt as administrator and backup database.
+   ```sh
+   shell> cd Documents
+   shell> "\Program Files\MySQL\MySQL Server 5.7\bin\mysqldump.exe" -uroot -p -l --add-drop-table cacti > cacti-version-YYYYMMDD.sql
+   ```
+
+3. Backup the old Cacti directory.
+   ```sh
+   shell> cd \inetpub\wwwroot
+   shell> robocopy cacti cacti-version-YYYYMMDD /s /b /copyall
+   ```
+
+4. Windows Update
+
+5. MySQL Installer - update Catalog, then upgrade MySQL Server
+
+6. Overwrite new version to production folder by extracting contents of cacti-xxx folder in cacti-xxx.zip to C:\inetpub\wwwroot\cacti\ and replace files.
+
+7. Edit `include/config.php` and specify the MySQL user, password and database for your Cacti configuration.
+   ```sh
+   shell> notepad cacti/include/config.php
+   ```
+
+   ```php
+   $database_type = "mysql";
+   $database_default = "cacti";
+   $database_hostname = "localhost";
+   $database_username = "cactiuser";
+   $database_password = "cacti";
+   ```
+
+8. Point your web browser to:
+    `http://localhost/cacti/`
+
+   Follow the on-screen instructions so your database can be updated to the new version.
+
+   Open "MySQL 5.7 Command Line Client" and set variables as needed in following format:
+   ```sh
+   set global max_allowed_packet = 16777216;
+   set global tmp_table_size = 67108864;
+   set global join_buffer_size = 67108864;
+   set global innodb_flush_log_at_timeout = 3;
+   ```
+
+9. Start poller.  Cacti > Configuration > Settings > Poller > check Data Collection Enabled and Save.
+
+---
+Copyright (c) 2018 Cacti Group

--- a/Upgrading-Cacti-Under-Windows.md
+++ b/Upgrading-Cacti-Under-Windows.md
@@ -2,8 +2,8 @@
 
 Download latest cacti-xxx.zip
 
-1. Stop poller.  
-Cacti > Configuration > Settings > Poller > uncheck Data Collection Enabled and Save.
+1. Stop poller.
+   Cacti > Configuration > Settings > Poller > uncheck Data Collection Enabled and Save.
 
 2. Run Command Prompt as administrator and backup database.
 
@@ -24,9 +24,11 @@ Cacti > Configuration > Settings > Poller > uncheck Data Collection Enabled and 
 5. MySQL Installer - update Catalog, then upgrade MySQL Server
 
 6. Overwrite new Cacti version to production folder.
-   Extract contents of cacti-xxx folder in cacti-xxx.zip to C:\inetpub\wwwroot\cacti\ and replace files.
+   Extract contents of cacti-xxx folder in cacti-xxx.zip to 
+   C:\inetpub\wwwroot\cacti\ and replace files.
 
-7. Edit `include/config.php` and specify the MySQL user, password and database for your Cacti configuration.
+7. Edit `include/config.php` and specify the MySQL user, password and database
+   for your Cacti configuration.
 
    ```sh
    shell> notepad cacti/include/config.php
@@ -55,7 +57,8 @@ Cacti > Configuration > Settings > Poller > uncheck Data Collection Enabled and 
    set global innodb_flush_log_at_timeout = 3;
    ```
 
-9. Start poller.  Cacti > Configuration > Settings > Poller > check Data Collection Enabled and Save.
+9. Start poller.
+   Cacti > Configuration > Settings > Poller > check Data Collection Enabled and Save.
 
 ---
 Copyright (c) 2018 Cacti Group

--- a/Upgrading-Cacti-Under-Windows.md
+++ b/Upgrading-Cacti-Under-Windows.md
@@ -1,12 +1,16 @@
 # Upgrading Cacti under Windows
-> Download latest cacti-xxx.zip
 
-1. Stop poller.  Cacti > Configuration > Settings > Poller > uncheck Data Collection Enabled and Save.
+Download latest cacti-xxx.zip
+
+1. Stop poller.  
+Cacti > Configuration > Settings > Poller > uncheck Data Collection Enabled and Save.
 
 2. Run Command Prompt as administrator and backup database.
+
    ```sh
    shell> cd Documents
-   shell> "\Program Files\MySQL\MySQL Server 5.7\bin\mysqldump.exe" -uroot -p -l --add-drop-table cacti > cacti-version-YYYYMMDD.sql
+   shell> "\Program Files\MySQL\MySQL Server 5.7\bin\mysqldump.exe" -uroot -p -l 
+   --add-drop-table cacti > cacti-version-YYYYMMDD.sql
    ```
 
 3. Backup the old Cacti directory.
@@ -19,9 +23,11 @@
 
 5. MySQL Installer - update Catalog, then upgrade MySQL Server
 
-6. Overwrite new version to production folder by extracting contents of cacti-xxx folder in cacti-xxx.zip to C:\inetpub\wwwroot\cacti\ and replace files.
+6. Overwrite new Cacti version to production folder.
+   Extract contents of cacti-xxx folder in cacti-xxx.zip to C:\inetpub\wwwroot\cacti\ and replace files.
 
 7. Edit `include/config.php` and specify the MySQL user, password and database for your Cacti configuration.
+
    ```sh
    shell> notepad cacti/include/config.php
    ```
@@ -35,11 +41,13 @@
    ```
 
 8. Point your web browser to:
+
     `http://localhost/cacti/`
 
    Follow the on-screen instructions so your database can be updated to the new version.
 
    Open "MySQL 5.7 Command Line Client" and set variables as needed in following format:
+   
    ```sh
    set global max_allowed_packet = 16777216;
    set global tmp_table_size = 67108864;


### PR DESCRIPTION
The current published documentation does not include upgrade information for Windows.  I propose this documentation as a separate file from Upgrading-Cacti.md, but it could also be added or combined with that file.

I have created instructions loosely based on the current Upgrading-Cacti.md file and the legacy Windows page from version 0.88.
https://docs.cacti.net/manual:088:1_installation.3_upgrading#windows