### PR TITLE
Granting access to timezone names without SUPER

### DIFF
--- a/General-Installing-Instructions.md
+++ b/General-Installing-Instructions.md
@@ -169,7 +169,8 @@ MySQL> flush privileges;
 Note that if your `root` (or equivalent) user does not have `SUPER` permissions, it may still be possible to `GRANT SELECT` privileges to the Cacti user via an `INSERT INTO mysql.tables_priv`.
 
 ```sql
-INSERT INTO mysql.tables_priv (Host, Db, User, Table_name, Grantor, Table_priv) VALUES ('localhost', 'mysql', 'cactiuser', 'time_zone_name', 'root@localhost', 'Select');
+INSERT INTO mysql.tables_priv (Host, Db, User, Table_name, Grantor, Table_priv)
+VALUES ('localhost', 'mysql', 'cactiuser', 'time_zone_name', 'root@localhost', 'Select');
 ```
 
 5. Edit `include/config.php` and specify the database type, name, host, user

--- a/General-Installing-Instructions.md
+++ b/General-Installing-Instructions.md
@@ -166,6 +166,12 @@ MySQL> GRANT SELECT ON mysql.time_zone_name TO cactiuser@localhost IDENTIFIED BY
 MySQL> flush privileges;
 ```
 
+Note that if your `root` (or equivalent) user does not have `SUPER` permissions, it may still be possible to `GRANT SELECT` privileges to the Cacti user via an `INSERT INTO mysql.tables_priv`.
+
+```sql
+INSERT INTO mysql.tables_priv (Host, Db, User, Table_name, Grantor, Table_priv) VALUES ('localhost', 'mysql', 'cactiuser', 'time_zone_name', 'root@localhost', 'Select');
+```
+
 5. Edit `include/config.php` and specify the database type, name, host, user
    and password for your Cacti configuration.
 


### PR DESCRIPTION
Some cloud hosted SQL providers do not provide `SUPER` access to their `root` users. This workaround makes it possible to `GRANT SELECT on mysql.time_zone_name` without `SUPER`.

Closes Cacti/cacti#2516