### PR TITLE
Update installing guides for NO_AUTO_CREATE_USER

### DIFF
--- a/General-Installing-Instructions.md
+++ b/General-Installing-Instructions.md
@@ -251,9 +251,12 @@ back into rotation.
 
    ```sql
    shell> mysql --user=root mysql
-   MySQL> GRANT ALL ON cacti.* TO cactiuser@localhost IDENTIFIED BY 'somepassword';
-   MySQL> GRANT SELECT ON mysql.time_zone_name TO cactiuser@localhost IDENTIFIED BY 'somepassword';
-   MySQL> flush privileges;
+   mysql> CREATE DATABASE cacti
+   mysql> CREATE USER 'cacti'@'localhost';
+   mysql> ALTER USER 'cacti'@'localhost' IDENTIFIED BY 'somepassword';
+   mysql> GRANT ALL PRIVILEGES ON cacti.* to 'cacti'@'localhost';
+   mysql> GRANT SELECT ON mysql.time_zone_name TO 'cacti'@'localhost';
+   mysql> FLUSH PRIVILEGES;
    ```
 
     Note that if your `root` (or equivalent) user does not have `SUPER` permissions,


### PR DESCRIPTION
After MySQL 8 started using NO_AUTO_CREATE_USER by default, the general installing instructions need update to instruct one on how to proper create the user separately from the ALTER SQL command given by example.

This compliments the changes for cacti issue Cacti/cacti#2872.

Signed-off-by: Rafael David Tinoco <rafaeldtinoco@ubuntu.com>