### PR TITLE
Update Installation docs to bump min php version to  8.1 

### DIFF
--- a/General-Installing-Instructions.md
+++ b/General-Installing-Instructions.md
@@ -1,5 +1,8 @@
 # General Installing Instructions
 
+> **Note**: As of Cacti 1.2.31, PHP 8.1 is required and PHP Composer is required. 
+> Composer will be used to ensure all of the libraries are installed and are up to date.
+
 Make sure the following packages are installed according to your operating
 systems requirements. Verify, that httpd/apache and MySQL/MariaDB are started at
 system startup.

--- a/Install-Under-CentOS_LAMP.md
+++ b/Install-Under-CentOS_LAMP.md
@@ -1,22 +1,17 @@
 # Installing on CentOS/RHEL/ROCKY
 
+> **Note**: As of Cacti 1.2.31, PHP 8.1 is required and PHP Composer is required. 
+> Composer will be used to ensure all of the libraries are installed and are up to date.
+
 ## LAMP (Linux, Apache, MySQL/MariaDB, PHP) Required packages
 
 ### Web Server (Apache)
 
-1. Enable Epel repo to enable PHP 7.2 package download ( 7.x and Below)
-
-   ```console
-   yum install http://rpms.remirepo.net/enterprise/remi-release-7.rpm -y
-   yum install yum-utils -y
-   yum-config-manager --enable remi-php72
-   ```
-
-   For Centos/RHEL/ROCKY 8+
+1. For Centos/RHEL/ROCKY 8+
 
    ```console
    dnf module reset php
-   dnf module enable php:8.0
+   dnf module enable php:8.1
    ```
 
 ### A special Note on installing Cacti in LXC Containers such as the ones found on Proxmox
@@ -317,7 +312,7 @@ PHP and various packages are all required by Cacti for successful operation
    php-mysqlnd php-gd php-gmp php-intl \
    php-json php-ldap php-mbstring \
    php-pdo php-pear php-snmp php-process \
-   php-xml php-zip
+   php-xml php-zip composer
    ```
 
 2. Set a timezone to your PHP.INI configuration

--- a/Install-Under-CentOS_LEMP.md
+++ b/Install-Under-CentOS_LEMP.md
@@ -1,5 +1,8 @@
 # Installing on CentOS 7
 
+> **Note**: As of Cacti 1.2.31, PHP 8.1 is required and PHP Composer is required. 
+> Composer will be used to ensure all of the libraries are installed and are up to date.
+
 ## LEMP (Linux, Nginx, MySQL, PHP) Required packages
 
 ### Web Server
@@ -313,7 +316,7 @@ PHP and various packages are all required by Cacti for successful operation
    php-mysqlnd php-gd php-gmp php-intl \
    php-json php-ldap php-mbstring \
    php-pdo php-pear php-snmp php-process \
-   php-xml php-zip php-fpm
+   php-xml php-zip php-fpm composer
    ```
 
 ---

--- a/Installing-Under-Ubuntu-Debian.md
+++ b/Installing-Under-Ubuntu-Debian.md
@@ -1,10 +1,13 @@
 # Installing Cacti 1.x  in Ubuntu/Debian LAMP stack
 
+> **Note**: As of Cacti 1.2.31, PHP 8.1 is required and PHP Composer is required. 
+> Composer will be used to ensure all of the libraries are installed and are up to date.
+
 ## Installing the required packages needed for the LAMP stack
 
 ```console
 apt-get update
-apt-get install -y apache2 rrdtool mariadb-server snmp snmpd php8.0 php8.0-mysql php8.0-snmp php8.0-xml php8.0-mbstring php8.0-json php8.0-gd php8.0-gmp php8.0-zip php8.0-ldap php8.0-mbstring
+apt-get install -y apache2 rrdtool mariadb-server snmp snmpd php8.1 php8.1-mysql php8.1-snmp php8.1-xml php8.1-mbstring php8.1-json php8.1-gd php8.1-gmp php8.1-zip php8.1-ldap php8.1-mbstring composer
 ```
 
 ### A special note for systems using PHP-FPM

--- a/Installing-Under-Windows.md
+++ b/Installing-Under-Windows.md
@@ -1,5 +1,8 @@
 # Installing Under Windows
 
+> **Note**: As of Cacti 1.2.31, PHP 8.1 is required and PHP Composer is required. 
+> Composer will be used to ensure all of the libraries are installed and are up to date.
+
 BSOD2600, one of the long term users of Cacti, provides an Installer on Windows.
 We recommend you use that installer for Cacti. You can obtain that installer
 under the Windows section of the Cacti forums. However, if you wish to install

--- a/Requirements.md
+++ b/Requirements.md
@@ -2,6 +2,9 @@
 
 Cacti requires that the following software is installed on your system.
 
+> **Note**: As of Cacti 1.2.31, PHP 8.1 is required and PHP Composer is required. 
+> Composer will be used to ensure all of the libraries are installed and are up to date.
+
 - Web Server that supports PHP e.g. Apache, Nginx, or IIS
 
 - Build environment when using spine (gcc, automake, autoconf, libtool,


### PR DESCRIPTION
This pull request updates installation and requirements documentation to reflect new prerequisites for Cacti 1.2.31. The most important changes are the requirement for PHP 8.1 and PHP Composer across all supported platforms, and updates to package installation instructions to ensure Composer is included.

**Documentation updates for new prerequisites:**

* Added a prominent note to all installation and requirements guides stating that PHP 8.1 and PHP Composer are now required as of Cacti 1.2.31, and Composer will be used to manage library dependencies. [[1]](diffhunk://#diff-c4457c49d38de1e6753a186bed7fd421da6f6666e90779369d1d237302c26e25R3-R5) [[2]](diffhunk://#diff-06c109e2018de9221674ac798d224fb2b8fdb1bcc9a0bf37c2514b62685d8f7bR3-R14) [[3]](diffhunk://#diff-e7318fca6f07933a98fd1e5f8670ad7110086e281fde89b1ff11572bce9e1431R3-R5) [[4]](diffhunk://#diff-68652f5550d719c2fcfee150b1eb36ca5ff72cecd6dc0aa292394ad495f446a1R3-R10) [[5]](diffhunk://#diff-b13cf59f0398447f5357094156b225adfb11f6fda76e865654028aab1f509796R3-R5) [[6]](diffhunk://#diff-f352eea7f6f774a1699fa919d20b39121b8e7d031f06559038f8a27212baff74R5-R7)

**Platform-specific installation instructions:**

* Updated CentOS/RHEL/ROCKY LAMP and LEMP installation guides to require the PHP 8.1 module instead of 8.0 or 7.2, and added `composer` to the list of required PHP packages. [[1]](diffhunk://#diff-06c109e2018de9221674ac798d224fb2b8fdb1bcc9a0bf37c2514b62685d8f7bR3-R14) [[2]](diffhunk://#diff-06c109e2018de9221674ac798d224fb2b8fdb1bcc9a0bf37c2514b62685d8f7bL320-R315) [[3]](diffhunk://#diff-e7318fca6f07933a98fd1e5f8670ad7110086e281fde89b1ff11572bce9e1431L316-R319)
* Updated Ubuntu/Debian installation guide to use PHP 8.1 and include `composer` in the package installation command.

These changes ensure users are aware of the new PHP and Composer requirements and can successfully install Cacti 1.2.31 on all supported platforms.