### PR TITLE
docs: add hardware sizing section and remove removed MySQL 8 variables from Requirements.md

### DIFF
--- a/Requirements.md
+++ b/Requirements.md
@@ -1,5 +1,36 @@
 # Requirements
 
+## Hardware Sizing
+
+The table below covers common deployment sizes. These are starting points; actual
+requirements depend on polling interval, number of data sources per device, use of
+Spine vs cmd.php, and whether remote pollers are used.
+
+| Deployment size | Devices | Data sources | CPU cores | RAM | Disk |
+|---|---|---|---|---|---|
+| Small | < 500 | < 50,000 | 2 | 4 GB | 50 GB SSD |
+| Medium | 500–2,000 | 50,000–500,000 | 4–8 | 16 GB | 200 GB SSD |
+| Large | 2,000–10,000 | 500,000–2,000,000 | 8–16 | 32–64 GB | 1 TB NVMe |
+| Very large | > 10,000 | > 2,000,000 | 16+ | 64+ GB | 2+ TB NVMe |
+
+**Notes:**
+
+- Use SSD or NVMe for the RRD file directory. RRDtool performs many small random
+  writes; spinning disk causes polling backlogs on medium and larger installs.
+- The MySQL/MariaDB data directory benefits from SSD as well.
+  `innodb_doublewrite` protects against torn page writes during a crash;
+  disabling it reduces crash safety on any storage type, including SSD/NVMe.
+  Setting `innodb_doublewrite = OFF` is an advanced optimization; only
+  consider it when you accept the durability trade-off (e.g. strong
+  backup/replication strategy and tolerance for potential data loss on an
+  unclean shutdown).
+- Spine is CPU-bound. Each spine process spawns threads up to your configured
+  maximum; allocate 1–2 spine processes per CPU core for best throughput.
+- Very large deployments (> 10,000 devices) require remote pollers deployed close to the devices
+  they poll rather than scaling a single main poller vertically.
+
+## Software Requirements
+
 Cacti requires that the following software is installed on your system.
 
 > **Note**: As of Cacti 1.2.31, PHP 8.1 is required. When installing from source or
@@ -35,17 +66,17 @@ Cacti requires that the following software is installed on your system.
     SELinux or AppArmor system-wide is a security regression and is not
     recommended for production systems.
 
-- MySQL 5.7 or MariaDB 10.2 or greater
+- MySQL 8.0 or MariaDB 10.6.28 or greater
   - Timezone support must be enabled
 
   - The following are my.cnf recommendations:
 
-    - **version >= 5.7 (MySQL) / 10.2 (MariaDB)**
+    - **version >= 8.0 (MySQL) / 10.6.28 (MariaDB)**
 
-      MySQL 5.7+ and MariaDB 10.2+ are the minimum supported versions.
-      Make sure you run the very latest release though, which fixes a long
-      standing low level networking issue that was causing spine many issues
-      with reliability.
+      MySQL 8.0+ and MariaDB 10.6.28+ are the minimum supported versions.
+      MariaDB 11.8.8 or greater is recommended for new installs. Run the
+      latest maintenance release for your chosen branch; older patch releases
+      have known networking issues that cause intermittent Spine failures.
 
     - **innodb = ON**
 
@@ -139,6 +170,18 @@ Cacti requires that the following software is installed on your system.
       migrate to the per file storage by enabling the feature, and then
       running an alter statement on all InnoDB tables.
 
+    - **innodb_data_file_path = ibdata1:12M:autoextend:autoshrink** (MariaDB 11.2.0+)
+
+      Long running installs that accumulated blocking queries can end up with a
+      very large ibdata1 file that never shrinks back down.  The autoshrink
+      attribute lets MariaDB truncate the system tablespace back toward its
+      minimum size.  It is off by default and is enabled by appending
+      :autoshrink to innodb_data_file_path, not by a separate variable.
+
+      From MariaDB 11.2.3 the shrink runs during a slow shutdown, so set
+      innodb_fast_shutdown = 0 before stopping the server or the file will not
+      be truncated.  MySQL has no equivalent.
+
     - **innodb_buffer_pool_size >= 25% of system RAM**
 
       InnoDB will hold as much tables and indexes in system memory as is
@@ -150,8 +193,12 @@ Cacti requires that the following software is installed on your system.
 
     - **innodb_doublewrite = OFF**
 
-      With modern SSD type storage, this operation actually degrades the disk
-      more rapidly and adds a 50% overhead on all write operations.
+      Disables the InnoDB doublewrite buffer. This eliminates a 50% write
+      overhead on SSD/NVMe storage, but removes protection against partial page
+      writes on an unclean shutdown. Only set this on SSD or NVMe storage with
+      battery-backed or capacitor-backed write cache, or when the database is
+      on a volume with hardware-level write atomicity guarantees. Do not set on
+      spinning disk or consumer SSDs without power-loss protection.
 
     - ~~**innodb_additional_mem_pool_size**~~ (removed in MySQL 5.7.4 / MariaDB 10.0)
 
@@ -226,8 +273,7 @@ paste them into my.cnf
  innodb_buffer_pool_size = 250M
  innodb_io_capacity = 5000
  innodb_io_capacity_max = 10000
- # innodb_file_format and innodb_large_prefix are removed in MySQL 8.0; omit on MySQL 8.0+ / MariaDB 10.3+
- ```
+```
 
 ---
 Copyright (c) 2004-2026 The Cacti Group


### PR DESCRIPTION
Closes #215
Refs #106

## Summary

- Add **Hardware Sizing** section to Requirements.md with a sizing table covering small (< 500 devices), medium (500-2,000), large (2,000-10,000), and very large (> 10,000) deployments, including guidance on:
  - SSD/NVMe requirement for RRD file directory (spinning disk causes polling backlogs)
  - `innodb_doublewrite = OFF` only appropriate on SSD
  - Spine CPU threading: 1-2 processes per CPU core
  - Remote data collectors for very large deployments
  - Note on memory vs InnoDB engine for Boost tables on large installs (refs #106)

- Remove `innodb_additional_mem_pool_size` from the description list (removed in MySQL 5.7.4; causes startup failure on any current MySQL or MariaDB)

- Remove `innodb_file_format = Barracuda` and `innodb_large_prefix = 1` from the paste-in config block at the bottom of the file (both removed in MySQL 8.0; cause startup failure)

## Test plan

- [ ] Verify sizing table numbers are consistent with community guidance
- [ ] Verify MySQL 8.0 no longer accepts `innodb_additional_mem_pool_size`, `innodb_file_format`, `innodb_large_prefix`
- [ ] Verify config paste-in block still works on MariaDB 10.5+