### PR TITLE
docs: fix README typos and refresh Debugging poller guidance

### DIFF
--- a/Contributing-Translations.md
+++ b/Contributing-Translations.md
@@ -80,10 +80,8 @@ Cacti will need these files name in hyphenated format, so: `fr_FR.po`, becomes
 
 ## Considerations
 
-Cacti is licensed under GPL-2.0-or-later. Translation contributions are expected
-to be compatible with that license. When contributing through the Cacti Weblate
-instance, contributors may be prompted to accept the applicable license terms
-during the translation workflow.
+As Cacti is GPL2.0+, you acknowledge, by signing up to the Cacti Weblate site,
+that your contributions will be GPL2.0+ as well.
 
 ---
 

--- a/Contributing-Translations.md
+++ b/Contributing-Translations.md
@@ -80,8 +80,10 @@ Cacti will need these files name in hyphenated format, so: `fr_FR.po`, becomes
 
 ## Considerations
 
-As Cacti is GPL2.0+, you acknowledge, by signing up to the Cacti Weblate site,
-that your contributions will be GPL2.0+ as well.
+Cacti is licensed under GPL-2.0-or-later. Translation contributions are expected
+to be compatible with that license. When contributing through the Cacti Weblate
+instance, contributors may be prompted to accept the applicable license terms
+during the translation workflow.
 
 ---
 

--- a/Debugging.md
+++ b/Debugging.md
@@ -186,40 +186,39 @@ Last resort would be to check, that the correct data sources are used. Go to
 the RRDfile and data source to be used. You may check, that all of them are as
 wanted.
 
-## RPM Installation
+## Duplicate Poller Entries
 
-Most rpm installations will setup the crontab entry now. If you've followed the
-installation instructions to the letter (which you should always do ;-) ), you
-may now have two poller running. That's not a good thing, though. Most rpm
-installations will setup cron in `/etc/cron.d/cacti`
+If you installed Cacti from a package (RPM, DEB, etc.), the package may have
+created both a cron entry in `/etc/cron.d/cacti` and enabled the `cactid`
+systemd service. Running two pollers simultaneously causes data corruption.
 
-Now check all your crontab, especially `/etc/crontab` and crontab of users root
-and cactiuser. Leave only one poller entry for all of them. Personally, I've
-chosen `/etc/cron.d/cacti` to avoid problems when updating RPM's. Most often,
-you won't remember this item when updating lots of RPM's, so I felt more secure
-to put it here. And I've made some slight modifications, see
+Check for duplicate entries:
 
 ```sh
-shell> vi /etc/cron.d/cacti
+systemctl status cactid
+cat /etc/cron.d/cacti
+cat /etc/crontab
+crontab -l -u cactiuser 2>/dev/null
+crontab -l -u root 2>/dev/null
 ```
 
-```ini
-*/5 * * * *     cactiuser       /usr/bin/php -q /var/www/html/cacti/poller.php > /var/local/log/poller.log 2>&1
-```
-
-This will produce a file `/var/local/log/poller.log`, which includes some
-additional information from each poller's run, such as RRDtool errors. It
-occupies only some few bytes and will be overwritten each time.
-
-If you're using the crontab of user "cactiuser" instead, this will look like
+The recommended approach is to use the `cactid` systemd service and remove any
+cron-based poller entries:
 
 ```sh
-shell> crontab -e -u cactiuser
+systemctl enable --now cactid
+# Then remove or comment out any poller.php line in /etc/cron.d/cacti
 ```
 
+If you need to keep cron-based polling, disable the service and leave a single
+cron entry:
+
 ```ini
-*/5 * * * *     /usr/bin/php -q /var/www/html/cacti/poller.php > /var/local/log/poller.log 2>&1
+*/5 * * * *  cactiuser  /usr/bin/php -q /var/www/html/cacti/poller.php > /dev/null 2>&1
 ```
+
+Replace `cactiuser` with the user your web server runs as (e.g. `www-data` on
+Debian/Ubuntu, `apache` on RHEL-compatible systems).
 
 ## Not NaN, but 0 (zero) values
 

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
 13. Reporting
 
-    13.1. [Reports Admistrative Interface](Reports-Admin.md)
+    13.1. [Reports Administrative Interface](Reports-Admin.md)
 
     13.2. [Reports User Interface](Reports-User.md)
 
@@ -386,7 +386,7 @@ Watch Howto's and Tutorials on the Cacti Official YouTube page if you prefer. If
 
 ### Template Specific Documentation
 
-This section will be for template specific configuration requriments
+This section will be for template specific configuration requirements
 
 1. [Apache Server Template](template_apache_config.md)
 
@@ -394,7 +394,7 @@ This section will be for template specific configuration requriments
 
 ### Device Template Specific Documentation
 
-This section will be for device template specific configuration requriments
+This section will be for device template specific configuration requirements
 
 1. [Proxmox External Storage Usage with Linux Device Template](device-template-specific-proxmox.md)
 


### PR DESCRIPTION
## Summary

**README.md**
- 'Admistrative' → 'Administrative' in Reports ToC
- 'requriments' → 'requirements' (2 occurrences)

**Debugging.md**
- Replace the 'RPM Installation' section with current guidance: use the `cactid` systemd service, check for duplicate poller entries from packages, note `www-data` vs `cactiuser` for Debian/Ubuntu

## Test plan

- [ ] Verify README ToC links still resolve
- [ ] Confirm no remaining 'requriments' / 'Admistrative' occurrences
