### PR TITLE
docs: fix SQL syntax error, stale version references, and prose errors in misc files

### DIFF
--- a/Boost.md
+++ b/Boost.md
@@ -2,11 +2,11 @@
 
 ## Summary
 
-Cacti Performance Settings, formally known as `boost` are available to support
+Cacti Performance Settings, formerly known as `boost` are available to support
 very large Cacti installations, and are required for supporting the multiple
 **Data Collector** architecture that Cacti affords.
 
-Designed years ago, Boosts intent was to reduce the the main data collectors
+Designed years ago, Boost's intent was to reduce the main data collector's
 cycle time by caching writes to disk, and those writes would be handled by an
 out of band process currently known as `poller_boost.php`.
 
@@ -61,7 +61,7 @@ important. That will be explained in more detail later on in this chapter.
 ## Checking how your system is configured
 
 To see how your system is configured, you can goto
-`Console > Utilityes > System Utilities > View Boost Status` option, when you go
+`Console > Utilities > System Utilities > View Boost Status` option, when you go
 there, you will see an image similar to that below.
 
 ![Boost Status Screen](images/boost-status1.png)
@@ -119,17 +119,17 @@ column, even though the column type is `varchar()`. By default it's
 `varchar(512)`. Therefore, if your system only needs 50 bytes, you will have 90%
 waste in your `poller_output_boost` table.
 
-The next step would me to modify the structure of your `poller_output` and
+The next step would be to modify the structure of your `poller_output` and
 `poller_output_boost` tables. You would do this by doing the following:
 
 ```sql
-ALTER TABLE poller_output,
-    MODIFY column output varchar(50) NOT NULL default ""
-    ENGINE=memory;
+ALTER TABLE poller_output
+    MODIFY COLUMN output varchar(50) NOT NULL DEFAULT '',
+    ENGINE=MEMORY;
 
-ALTER TABLE poller_output_boost,
-    MODIFY column output varchar(50) NOT NULL default ""
-    ENGINE=memory;
+ALTER TABLE poller_output_boost
+    MODIFY COLUMN output varchar(50) NOT NULL DEFAULT '',
+    ENGINE=MEMORY;
 ```
 
 As previously mentioned, its also important that the `poller_output` table is
@@ -174,7 +174,7 @@ max_heap_table_size=132M
 ```
 
 Then, save the file, and restart MySQL. Once this is done, you are ready to
-“enable” Boost as described above.
+"enable" Boost as described above.
 
 ## Flushing the Boost Cache
 

--- a/Cacti-SSL-Configuration.md
+++ b/Cacti-SSL-Configuration.md
@@ -1,18 +1,21 @@
-# Configuring and enabling SSL for Cacti with a self signed certificate
+# Configuring and enabling SSL for Cacti with a self-signed certificate
 
-Enabling SSL for Cacti is mostly done at the webserver level. An example SSL
-config for HTTP is as follows:
+Enabling SSL for Cacti is done at the web server level. An example HTTPS
+configuration for Apache is as follows:
 
 ```bash
-yum install -y mod_ssl -y
-openssl genrsa -out ca.key 2048
+yum install -y mod_ssl
+openssl genrsa -out ca.key 4096
 openssl req -new -key ca.key -out ca.csr
 openssl x509 -req -days 700 -in ca.csr -signkey ca.key -out ca.crt
 cp ca.crt /etc/pki/tls/certs
 cp ca.key /etc/pki/tls/private/ca.key
 cp ca.csr /etc/pki/tls/private/ca.csr
-
 ```
+
+> **Note on key size**: A 4096-bit RSA key is used above. NIST SP 800-57
+> recommends a minimum of 3072 bits for RSA keys through 2030. 2048-bit keys
+> are below that threshold and should not be used for new certificates.
 
 Then we need to update the Apache SSL configuration file:
 
@@ -28,16 +31,17 @@ Restart the httpd service:
 systemctl restart httpd
 ```
 
-After configuring the web server to accept https, you can enable https in the
-GUI
+After configuring the web server to accept HTTPS, you can enable HTTPS in the
+GUI.
+
+> **Note for public-facing servers**: Instead of a self-signed certificate,
+> use a certificate from a trusted CA. [Certbot](https://certbot.eff.org/)
+> from Let's Encrypt provides free, automatically-renewed certificates and
+> is the recommended approach for any internet-accessible Cacti instance.
 
 ---
 
 **Note**: if using multiple pollers, all must have HTTPS enabled for the remote polling feature to work properly.
-
----
-
-**Note**: If your Cacti system is public, it is recommended to get a certificate from a trusted certificate provider.
 
 ---
 

--- a/Contributing-Translations.md
+++ b/Contributing-Translations.md
@@ -80,7 +80,7 @@ Cacti will need these files name in hyphenated format, so: `fr_FR.po`, becomes
 
 ## Considerations
 
-As Cacti is GPL2.0+, you acknowledge, by sigining up to the Cacti Weblate site,
+As Cacti is GPL2.0+, you acknowledge, by signing up to the Cacti Weblate site,
 that your contributions will be GPL2.0+ as well.
 
 ---

--- a/Debugging.md
+++ b/Debugging.md
@@ -186,29 +186,6 @@ Last resort would be to check, that the correct data sources are used. Go to
 the RRDfile and data source to be used. You may check, that all of them are as
 wanted.
 
-## Miscellaneous
-
-Up to current cacti 0.8.6h, table `poller_output` may increase beyond reasonable
-size.
-
-This is commonly due to php.ini's memory settings of 8MB default. Change this to
-at least 64 MB.
-
-To check this, run the following SQL from MySQL CLI (or phpMyAdmin or the like)
-
-```sql
-select count(*) from poller_output;
-```
-
-If the result is huge, you may get rid of those stuff by
-
-```sql
-truncate table poller_output;
-```
-
-As of current SVN code for upcoming cacti 0.9, I saw measures were taken on both
-issues (memory size, truncating poller_output).
-
 ## RPM Installation
 
 Most rpm installations will setup the crontab entry now. If you've followed the
@@ -248,7 +225,7 @@ shell> crontab -e -u cactiuser
 
 Pay attention to custom scripts. It is required, that external commands called
 from there are in the `$PATH` of the cactiuser running the poller. It is
-therefor recommended to provide `/full/path/to/external/command`
+therefore recommended to provide `/full/path/to/external/command`
 
 User "criggie" reported an issue with running smartctl. It was complaining "you
 are not root" so a quick `chmod +s` on the script fixed that problem.

--- a/Principles-of-Operation.md
+++ b/Principles-of-Operation.md
@@ -1,6 +1,6 @@
 # Principles of Operation
 
-To understand Cacti's principal of operation, you have to start
+To understand Cacti's principles of operation, you have to start
 at the top and work down.  Cacti's operational model is
 divided into multiple layers.  They include
 
@@ -15,34 +15,34 @@ divided into multiple layers.  They include
 
 Cacti **Devices** are either physical hosts, sensors, clusters,
 services, or any type of object with a name and that can
-provide information about it self that should go into a
+provide information about itself that should go into a
 **Graph** or could be used to provide additional information
 useful for Operations.
 
 The Cacti **Device** object serves as the center Cacti's world
-it's where stores information on how gather data about it.  You
+it stores information on how to gather data about it.  You
 can have from one to tens of thousands of **Devices** monitored
 from one Cacti system.  It's very scalable.  They can be
 discovered using Cacti's Automation sub-system, added manually,
-or gathered from a CMDB and added to Cacti using it's command
+or gathered from a CMDB and added to Cacti using its command
 line interface.
 
 ## Sites
 
-Cacti works with **Sites**.  So, when you add a phyical **Device**
+Cacti works with **Sites**.  So, when you add a physical **Device**
 to Cacti, you can associate it with a **Site**.  Sites are designed
-to be physical locations.  Cacti can organize **Devices** and it's
+to be physical locations.  Cacti can organize **Devices** and its
 **Graphs** by Site in a convenient fashion.
 
 ## Data Collectors
 
 These are the physical or virtual hosts or containers that gather
 data about a group of devices either within a network or a site.
-They are resiliant in that if the central Cacti server is not reachable,
+They are resilient in that if the central Cacti server is not reachable,
 they will cache data and wait for it to become available again.
 
-Cacti supports upto dozens of Data Collectors today.  Some customers
-use somethings as simple as a Raspberry Pi or Nuk for
+Cacti supports up to dozens of Data Collectors today.  Some customers
+use something as simple as a Raspberry Pi or Intel NUC for
 Data Collectors.  However, Virtual Machines are preferred as they
 can be migrated live which does not interrupt data collection.
 
@@ -79,7 +79,7 @@ can be nearer in latency than the database, can scale to 30,
 40, even 50 thousand devices with relative ease in Cacti
 depending on the size of your database and data collector
 infrastructure (sockets, cores, threads).  When using this
-N-Tiered methology, most customers will use Cacti's
+N-Tiered methodology, most customers will use Cacti's
 `script server` which is a pool of memory resident PHP
 interpreters that preloads all scripts used to gather data,
 therefore, it's super fast, and parallel in nature.
@@ -102,7 +102,7 @@ hammer.  Other approaches in the industry use SQL database,
 others flat files or document stores like ElasticSearch, Splunk,
 Mongo DB, InfluxDB.  There are a number of options out there.
 You can get more information about RRDfile from the
-[RRDtool Website](http://www.RRDtool.org/).
+[RRDtool Website](https://www.rrdtool.org/).
 
 `RRD` is an acronym for **Round Robin Database**. RRD is a system to store and
 display time-series data (i.e. network bandwidth, machine-room temperature,
@@ -118,7 +118,7 @@ different consolidation functions: AVERAGE, MAXIMUM, MINIMUM and LAST.
 
 ## Data Presentation
 
-One of the most appreciated features of [RRDtool](http://www.RRDtool.org/) is
+One of the most appreciated features of [RRDtool](https://www.rrdtool.org/) is
 the built-in graphing function. This comes in useful when combining this with
 some commonly used web server. Such, it is possible to access the graphs from
 merely any browser on any platform.
@@ -177,10 +177,10 @@ results with others.
 ## Beyond Graphs
 
 Cacti is not just a Graphing platform, it's also a Network Operations
-Framework.  Thought the dozens of plugins and user contributed
+Framework.  Through the dozens of plugins and user contributed
 Graph Templates, the sky is the limit as to what can be done using the
-Cacti Framework.  It's stood the test of time now in it's 19th year
-of existence in the Open Source world.
+Cacti Framework.  It's stood the test of time now for over two decades
+in the Open Source world.
 
 ---
 Copyright (c) 2004-2026 The Cacti Group

--- a/Requirements.md
+++ b/Requirements.md
@@ -104,10 +104,12 @@ Cacti requires that the following software is installed on your system.
       the only feature in MariaDB or MySQL becomes temporary table space
       which may not be dependent on the **max_heap_table_size**.
 
-    - **table_cache >= 200**
+    - **table_open_cache >= 200**
 
       Keeping the table cache larger means less file open/close operations
-      when using innodb_file_per_table.
+      when using innodb_file_per_table. (Note: `table_cache` was renamed to
+      `table_open_cache` in MySQL 5.1.3; use `table_open_cache` on all
+      current MySQL and MariaDB releases.)
 
     - **max_allowed_packet >= 16777216**
 
@@ -162,11 +164,6 @@ Cacti requires that the following software is installed on your system.
       Setting this value to 2 means that you will flush all transactions every
       second rather than at commit.  This allows MySQL/MariaDB to perform
       writing less often.
-
-    - **innodb_file_io_threads >= 16**
-
-      With modern SSD type storage, having multiple io threads is advantageous
-      for applications with high IO characteristics.
 
     - **innodb_flush_log_at_timeout >= 3**
 

--- a/Standards-Code-Formatting.md
+++ b/Standards-Code-Formatting.md
@@ -5,10 +5,10 @@
 Over the years Cacti has attempted to adhere to standards in code construction,
 syntax, style, etc. It has been a very organic grow which has resulted in some
 mixed styles. Cacti is in the process of moving to [PHP Standards
-Recommendations](http://www.php-fig.org/psr/) (PSR) standards.
+Recommendations](https://www.php-fig.org/psr/) (PSR) standards.
 
-Initially we are moving towards [PSR-2](http://www.php-fig.org/psr/psr-2/) code
-syntax standard with the following exceptions:
+Initially we are moving towards [PSR-12](https://www.php-fig.org/psr/psr-12/)
+(Extended Coding Style) with the following exceptions:
 
 - Initial white space must be tabs not spaces followed by the use of spaces to
   align elements after initial tab.
@@ -47,7 +47,7 @@ Tab stops should be set to 4 spaces.
 Below are the vim rules to accomplish this:
 
 ```console
-set expandtab
+set noexpandtab
 set shiftwidth=4
 set softtabstop=4
 set tabstop=4

--- a/Standards-Security.md
+++ b/Standards-Security.md
@@ -16,7 +16,7 @@ you are using unvalidated data.  They include:
 
 * get_filter_request_var('somevariable') - This function call, by default,
   will validate that the variable `$_REQUEST['somevariable']` returned
-  is actually an integer, if not, Cacti will block the the page
+  is actually an integer, if not, Cacti will block the page
   function from continuing.
 
 * get_filter_request_var('somevariable', 'options') - This version of the
@@ -28,8 +28,20 @@ you are using unvalidated data.  They include:
 Generally speaking, you should never use either `$_GET`, `$_REQUEST` or
 `$_POST` in your Cacti code.  Use the validators.  When you do, you can
 turn on the Cacti setting `Log Input Validation Issues` when you are
-developing, and you Cacti log will include warnings when an invalidate
+developing, and your Cacti log will include warnings when an invalid
 variable has been encountered.
+
+## OS Command Injection
+
+Never pass unsanitized input to shell execution functions (`exec()`,
+`shell_exec()`, `system()`, `passthru()`, `popen()`). Device fields,
+OID strings, community names, and any other user-influenced values must
+be treated as untrusted.
+
+Always escape arguments with `escapeshellarg()`. If you need to run an
+external command from a plugin, use Cacti's `api_plugin_safe_exec()` API
+where available, as it enforces an allowlist of permitted executables and
+strips dangerous characters before any shell invocation.
 
 ## Prepared Statements
 


### PR DESCRIPTION
Fix SQL syntax error in Boost.md: both ALTER TABLE statements had a trailing comma after the table name, breaking copy-paste.

Remove two stale MySQL settings from Requirements.md: `table_cache` (renamed to `table_open_cache` in MySQL 5.1.3) and `innodb_file_io_threads` (removed in MySQL 5.5, superseded by `innodb_read/write_io_threads` already documented in the same file).

Remove Debugging.md 'Miscellaneous' section referencing Cacti 0.8.6h and 'upcoming 0.9' (~18 years old); the issue it described was fixed before 1.0.

Fix prose errors in Boost.md, Principles-of-Operation.md, Contributing-Translations.md, and Standards-Security.md. See commit message for full list.

Update Cacti-SSL-Configuration.md: RSA key size 2048 -> 4096; fix 'HTTP' label in description text.